### PR TITLE
Add end-to-end tests

### DIFF
--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -1,0 +1,47 @@
+import * as core from '@actions/core'
+import CloudWatch from 'aws-sdk/clients/cloudwatch'
+import {postBuildStatus} from '../src/cw-build-status'
+
+jest.mock('aws-sdk/clients/cloudwatch')
+jest.mock('@actions/core')
+
+const MOCK_NAMESPACE = 'GithubCI'
+const MOCK_REPO = 'ros-tooling/action-cloudwatch-metrics'
+const MOCK_RETURN = 'success'
+
+describe('Integration test suite', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(core, 'getInput')
+        .mockReturnValueOnce(MOCK_NAMESPACE)  // namespace
+        .mockReturnValueOnce(MOCK_REPO)       // project-name
+        .mockReturnValueOnce(MOCK_RETURN)     // status
+  })
+
+  test('post build metrics successfully', async () => {
+    CloudWatch.prototype.putMetricData = jest.fn().mockImplementationOnce(() => {
+      return {
+        promise() {
+          return Promise.resolve({
+            error: null,
+            data: 'success'
+          })
+        }
+      }
+    })
+    await postBuildStatus()
+    expect(CloudWatch.prototype.putMetricData).toBeCalled()
+  })
+
+  test('fail when cloudwatch fails', async () => {
+    CloudWatch.prototype.putMetricData = jest.fn().mockImplementationOnce(() => {
+      return Promise.resolve({
+        error: Error('Could not post metrics'),
+        data: null
+      })
+    })
+    const mockSetFailed = jest.spyOn(core, 'setFailed')
+    await postBuildStatus()
+    expect(mockSetFailed).toHaveBeenCalled()
+  })
+})

--- a/__tests__/unit.test.ts
+++ b/__tests__/unit.test.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core'
 import {checkStatusString, createMetricDatum, publishMetricData} from '../src/cw-build-status'
 import CloudWatch from 'aws-sdk/clients/cloudwatch'
 
@@ -38,7 +39,11 @@ describe('unit test suite', () => {
         }
       }
     })
-
+    jest.spyOn(core, 'getInput')
+        .mockReturnValueOnce('GithubCI')  // namespace
+        .mockReturnValueOnce('ros-tooling/action-cloudwatch-metrics')  // project-name
+        .mockReturnValueOnce('success')  // status
+        
     const metricNamespace = 'MyNamespace'
     const metricName = 'MyMetric'
     const projectName = 'MyProject'
@@ -46,6 +51,7 @@ describe('unit test suite', () => {
     const value = 1.0
     const datum = createMetricDatum(metricName, projectName, isCronJob, value)
     const metricData = [datum]
+    
     publishMetricData(metricNamespace, metricData)
     expect(CloudWatch.prototype.putMetricData).toBeCalled()
   })


### PR DESCRIPTION
* Add end-to-end tests that verify the action succeeds or fails based on the response received.

Currently the response is mocked otherwise this test will require AWS credentials to run.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>