### PR TITLE
Add GitHub context to Metric Dimensions

### DIFF
--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -10,13 +10,13 @@ const MOCK_NAMESPACE = 'GithubCI'
 const MOCK_REPO = 'ros-tooling/action-cloudwatch-metrics'
 const MOCK_RETURN = 'success'
 const ENVIRONMENT_VARIABLE_OVERRIDES = {
-  GITHUB_REPOSITORY: 'MY-REPOSITORY-NAME',
-  GITHUB_WORKFLOW: 'MY-WORKFLOW-ID',
   GITHUB_ACTION: 'MY-ACTION-NAME',
   GITHUB_ACTOR: 'MY-USERNAME[bot]',
+  GITHUB_EVENT_PATH: path.join(__dirname, 'payload.json'),
   GITHUB_REF: 'MY-BRANCH',
+  GITHUB_REPOSITORY: 'MY-REPOSITORY-NAME',
   GITHUB_SHA: 'MY-COMMIT-ID',
-  GITHUB_EVENT_PATH: path.join(__dirname, 'payload.json')
+  GITHUB_WORKFLOW: 'MY-WORKFLOW-ID'
 }
 
 describe('Integration test suite', () => {

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core'
+import * as path from 'path'
 import CloudWatch from 'aws-sdk/clients/cloudwatch'
 import {postBuildStatus} from '../src/cw-build-status'
 
@@ -8,14 +9,26 @@ jest.mock('@actions/core')
 const MOCK_NAMESPACE = 'GithubCI'
 const MOCK_REPO = 'ros-tooling/action-cloudwatch-metrics'
 const MOCK_RETURN = 'success'
+const ENVIRONMENT_VARIABLE_OVERRIDES = {
+  GITHUB_REPOSITORY: 'MY-REPOSITORY-NAME',
+  GITHUB_WORKFLOW: 'MY-WORKFLOW-ID',
+  GITHUB_ACTION: 'MY-ACTION-NAME',
+  GITHUB_ACTOR: 'MY-USERNAME[bot]',
+  GITHUB_REF: 'MY-BRANCH',
+  GITHUB_SHA: 'MY-COMMIT-ID',
+  GITHUB_EVENT_PATH: path.join(__dirname, 'payload.json')
+}
 
 describe('Integration test suite', () => {
+  const OLD_ENV = process.env
+
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(core, 'getInput')
         .mockReturnValueOnce(MOCK_NAMESPACE)  // namespace
         .mockReturnValueOnce(MOCK_REPO)       // project-name
         .mockReturnValueOnce(MOCK_RETURN)     // status
+    process.env = {...OLD_ENV, ...ENVIRONMENT_VARIABLE_OVERRIDES};  
   })
 
   test('post build metrics successfully', async () => {

--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -6,9 +6,6 @@ import {postBuildStatus} from '../src/cw-build-status'
 jest.mock('aws-sdk/clients/cloudwatch')
 jest.mock('@actions/core')
 
-const MOCK_NAMESPACE = 'GithubCI'
-const MOCK_REPO = 'ros-tooling/action-cloudwatch-metrics'
-const MOCK_RETURN = 'success'
 const ENVIRONMENT_VARIABLE_OVERRIDES = {
   GITHUB_ACTION: 'MY-ACTION-NAME',
   GITHUB_ACTOR: 'MY-USERNAME[bot]',
@@ -18,6 +15,9 @@ const ENVIRONMENT_VARIABLE_OVERRIDES = {
   GITHUB_SHA: 'MY-COMMIT-ID',
   GITHUB_WORKFLOW: 'MY-WORKFLOW-ID'
 }
+const MOCK_NAMESPACE = 'GithubCI'
+const MOCK_REPO = 'ros-tooling/action-cloudwatch-metrics'
+const MOCK_RETURN = 'success'
 
 describe('Integration test suite', () => {
   const OLD_ENV = process.env

--- a/__tests__/payload.json
+++ b/__tests__/payload.json
@@ -1,0 +1,6 @@
+{
+  "pull_request": {
+      "number": 10
+  },
+  "action": "opened"
+}

--- a/__tests__/payload.json
+++ b/__tests__/payload.json
@@ -1,6 +1,6 @@
 {
   "pull_request": {
-      "number": 10
+    "number": 10
   },
   "action": "opened"
 }

--- a/__tests__/unit.test.ts
+++ b/__tests__/unit.test.ts
@@ -4,19 +4,33 @@ import CloudWatch from 'aws-sdk/clients/cloudwatch'
 
 jest.mock('aws-sdk/clients/cloudwatch')
 
+const ENVIRONMENT_VARIABLE_OVERRIDES = {
+  GITHUB_REPOSITORY: 'MY-REPOSITORY-NAME',
+  GITHUB_WORKFLOW: 'MY-WORKFLOW-ID',
+  GITHUB_ACTION: 'MY-ACTION-NAME',
+  GITHUB_ACTOR: 'MY-USERNAME[bot]',
+  GITHUB_REF: 'MY-BRANCH',
+  GITHUB_SHA: 'MY-COMMIT-ID',
+}
+
 describe('unit test suite', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {...OLD_ENV, ...ENVIRONMENT_VARIABLE_OVERRIDES};
+  })
 
   test('checkStatusString passes on valid success string', async () => {
       expect(() => {
         checkStatusString('success')
       }).not.toThrow()
-  });
+  })
 
   test('checkStatusString throws on invalid status string', async () => {
     expect(() => {
       checkStatusString('foo')
     }).toThrow()
-  });
+  })
 
   test('createMetricDatum returns valid datum', async () => {
     const metricName = 'MyMetric'
@@ -26,8 +40,7 @@ describe('unit test suite', () => {
     const result = createMetricDatum(metricName, projectName, isCronJob, value)
     expect(result.MetricName).toStrictEqual(metricName)
     expect(result.Value).toStrictEqual(value)
-    expect(result.Dimensions.length).toStrictEqual(2)
-  });
+  })
 
   test('publishMetricData calls SDK', async () => {
     CloudWatch.prototype.putMetricData = jest.fn().mockImplementationOnce(() => {

--- a/__tests__/unit.test.ts
+++ b/__tests__/unit.test.ts
@@ -40,6 +40,7 @@ describe('unit test suite', () => {
     const result = createMetricDatum(metricName, projectName, isCronJob, value)
     expect(result.MetricName).toStrictEqual(metricName)
     expect(result.Value).toStrictEqual(value)
+    expect(result.Dimensions.length).toBeGreaterThanOrEqual(1)
   })
 
   test('publishMetricData calls SDK', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -23251,19 +23251,19 @@ const github = __importStar(__webpack_require__(469));
 const cloudwatch_1 = __importDefault(__webpack_require__(967));
 const cloudwatch = new cloudwatch_1.default();
 const context = github.context;
-const FAILED_BUILDS_METRIC_NAME = 'FailedBuilds';
-const NUM_BUILDS_METRIC_NAME = 'Builds';
-const SUCCESS_BUILDS_METRIC_NAME = 'SucceededBuilds';
-const SCHEDULE_EVENT_NAME = 'schedule';
 const EVENT_NAME_DIMENSION = 'EventName';
+const FAILED_BUILD_STATUS = 'failure';
+const FAILED_BUILDS_METRIC_NAME = 'FailedBuilds';
+const FAILED_METRIC_VALUE = 0.0;
 const IS_CRON_JOB_DIMENSION = 'IsCronJob';
+const NUM_BUILDS_METRIC_NAME = 'Builds';
 const PROJECT_DIMENSION = 'ProjectName';
 const REPOSITORY_DIMENSION = 'Repository';
 const REFERENCE_DIMENSION = 'Reference';
-const WORKFLOW_DIMENSION = 'Workflow';
+const SCHEDULE_EVENT_NAME = 'schedule';
+const SUCCESS_BUILDS_METRIC_NAME = 'SucceededBuilds';
 const SUCCESS_METRIC_VALUE = 1.0;
-const FAILED_METRIC_VALUE = 0.0;
-const FAILED_BUILD_STATUS = 'failure';
+const WORKFLOW_DIMENSION = 'Workflow';
 function checkStatusString(status) {
     const validBuildStatusCheck = new RegExp('(success|failure)');
     if (!status.match(validBuildStatusCheck)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -23256,6 +23256,10 @@ const NUM_BUILDS_METRIC_NAME = 'Builds';
 const SUCCESS_BUILDS_METRIC_NAME = 'SucceededBuilds';
 const PROJECT_DIMENSION = 'ProjectName';
 const IS_CRON_JOB_DIMENSION = 'IsCronJob';
+const EVENT_NAME_DIMENSION = 'EventName';
+const WORKFLOW_DIMENSION = 'Workflow';
+const REFERENCE_DIMENSION = 'Reference';
+const REPOSITORY_DIMENSION = 'Repository';
 const SUCCESS_METRIC_VALUE = 1.0;
 const FAILED_METRIC_VALUE = 0.0;
 const FAILED_BUILD_STATUS = 'failure';
@@ -23274,7 +23278,11 @@ function createMetricDatum(metricName, projectName, isCronJob, value) {
         'Value': value,
         'Dimensions': [
             { 'Name': PROJECT_DIMENSION, 'Value': projectName },
-            { 'Name': IS_CRON_JOB_DIMENSION, 'Value': cronJobString }
+            { 'Name': IS_CRON_JOB_DIMENSION, 'Value': cronJobString },
+            { 'Name': EVENT_NAME_DIMENSION, 'Value': context.eventName },
+            { 'Name': WORKFLOW_DIMENSION, 'Value': context.workflow },
+            { 'Name': REFERENCE_DIMENSION, 'Value': context.ref },
+            { 'Name': REPOSITORY_DIMENSION, 'Value': context.repo.repo },
         ]
     };
     return metric_datum;

--- a/dist/index.js
+++ b/dist/index.js
@@ -23254,16 +23254,16 @@ const context = github.context;
 const FAILED_BUILDS_METRIC_NAME = 'FailedBuilds';
 const NUM_BUILDS_METRIC_NAME = 'Builds';
 const SUCCESS_BUILDS_METRIC_NAME = 'SucceededBuilds';
-const PROJECT_DIMENSION = 'ProjectName';
-const IS_CRON_JOB_DIMENSION = 'IsCronJob';
+const SCHEDULE_EVENT_NAME = 'schedule';
 const EVENT_NAME_DIMENSION = 'EventName';
-const WORKFLOW_DIMENSION = 'Workflow';
-const REFERENCE_DIMENSION = 'Reference';
+const IS_CRON_JOB_DIMENSION = 'IsCronJob';
+const PROJECT_DIMENSION = 'ProjectName';
 const REPOSITORY_DIMENSION = 'Repository';
+const REFERENCE_DIMENSION = 'Reference';
+const WORKFLOW_DIMENSION = 'Workflow';
 const SUCCESS_METRIC_VALUE = 1.0;
 const FAILED_METRIC_VALUE = 0.0;
 const FAILED_BUILD_STATUS = 'failure';
-const SCHEDULE_EVENT_NAME = 'schedule';
 function checkStatusString(status) {
     const validBuildStatusCheck = new RegExp('(success|failure)');
     if (!status.match(validBuildStatusCheck)) {
@@ -23277,12 +23277,12 @@ function createMetricDatum(metricName, projectName, isCronJob, value) {
         'MetricName': metricName,
         'Value': value,
         'Dimensions': [
-            { 'Name': PROJECT_DIMENSION, 'Value': projectName },
-            { 'Name': IS_CRON_JOB_DIMENSION, 'Value': cronJobString },
             { 'Name': EVENT_NAME_DIMENSION, 'Value': context.eventName },
-            { 'Name': WORKFLOW_DIMENSION, 'Value': context.workflow },
+            { 'Name': IS_CRON_JOB_DIMENSION, 'Value': cronJobString },
+            { 'Name': PROJECT_DIMENSION, 'Value': projectName },
             { 'Name': REFERENCE_DIMENSION, 'Value': context.ref },
             { 'Name': REPOSITORY_DIMENSION, 'Value': context.repo.repo },
+            { 'Name': WORKFLOW_DIMENSION, 'Value': context.workflow },
         ]
     };
     return metric_datum;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "cw-build-status",
-  "version": "0.0.0",
+  "name": "action-cloudwatch-metrics",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,13 +18,13 @@
       }
     },
     "@actions/github": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.1.0.tgz",
-      "integrity": "sha512-G4ncMlh4pLLAvNgHUYUtpWQ1zPf/VYqmRH9oshxLabdaOOnp7i1hgSgzr2xne2YUaSND3uqemd3YYTIsm2f/KQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.1.1.tgz",
+      "integrity": "sha512-kAgTGUx7yf5KQCndVeHSwCNZuDBvPyxm5xKTswW2lofugeuC1AZX73nUUVDNaysnM9aKFMHv9YCdVJbg7syEyA==",
       "requires": {
         "@actions/http-client": "^1.0.3",
         "@octokit/graphql": "^4.3.1",
-        "@octokit/rest": "^16.15.0"
+        "@octokit/rest": "^16.43.1"
       }
     },
     "@actions/http-client": {
@@ -1016,9 +1016,9 @@
       }
     },
     "@types/jest": {
-      "version": "25.1.2",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.1.2.tgz",
-      "integrity": "sha512-EsPIgEsonlXmYV7GzUqcvORsSS9Gqxw/OvkGwHfAdpjduNRxMlhsav0O5Kb0zijc/eXSO/uW6SJt9nwull8AUQ==",
+      "version": "25.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-25.1.3.tgz",
+      "integrity": "sha512-jqargqzyJWgWAJCXX96LBGR/Ei7wQcZBvRv0PLEu9ZByMfcs23keUJrKv9FMR6YZf9YCbfqDqgmY+JUBsnqhrg==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.1.0",
@@ -1032,9 +1032,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
-      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
+      "version": "13.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
+      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -1064,12 +1064,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.19.2.tgz",
-      "integrity": "sha512-HX2qOq2GOV04HNrmKnTpSIpHjfl7iwdXe3u/Nvt+/cpmdvzYvY0NHSiTkYN257jHnq4OM/yo+OsFgati+7LqJA==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.20.0.tgz",
+      "integrity": "sha512-cimIdVDV3MakiGJqMXw51Xci6oEDEoPkvh8ggJe2IIzcc0fYqAxOXN6Vbeanahz6dLZq64W+40iUEc9g32FLDQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.19.2",
+        "@typescript-eslint/experimental-utils": "2.20.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1077,32 +1077,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.2.tgz",
-      "integrity": "sha512-B88QuwT1wMJR750YvTJBNjMZwmiPpbmKYLm1yI7PCc3x0NariqPwqaPsoJRwU9DmUi0cd9dkhz1IqEnwfD+P1A==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.20.0.tgz",
+      "integrity": "sha512-fEBy9xYrwG9hfBLFEwGW2lKwDRTmYzH3DwTmYbT+SMycmxAoPl0eGretnBFj/s+NfYBG63w/5c3lsvqqz5mYag==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.19.2",
+        "@typescript-eslint/typescript-estree": "2.20.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.19.2.tgz",
-      "integrity": "sha512-8uwnYGKqX9wWHGPGdLB9sk9+12sjcdqEEYKGgbS8A0IvYX59h01o8os5qXUHMq2na8vpDRaV0suTLM7S8wraTA==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.20.0.tgz",
+      "integrity": "sha512-o8qsKaosLh2qhMZiHNtaHKTHyCHc3Triq6aMnwnWj7budm3xAY9owSZzV1uon5T9cWmJRJGzTFa90aex4m77Lw==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.19.2",
-        "@typescript-eslint/typescript-estree": "2.19.2",
+        "@typescript-eslint/experimental-utils": "2.20.0",
+        "@typescript-eslint/typescript-estree": "2.20.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.2.tgz",
-      "integrity": "sha512-Xu/qa0MDk6upQWqE4Qy2X16Xg8Vi32tQS2PR0AvnT/ZYS4YGDvtn2MStOh5y8Zy2mg4NuL06KUHlvCh95j9C6Q==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.20.0.tgz",
+      "integrity": "sha512-WlFk8QtI8pPaE7JGQGxU7nGcnk1ccKAJkhbVookv94ZcAef3m6oCE/jEDL6dGte3JcD7reKrA0o55XhBRiVT3A==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -1307,9 +1307,9 @@
       "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
     "aws-sdk": {
-      "version": "2.615.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.615.0.tgz",
-      "integrity": "sha512-ktkOQgJLTcsfLzy/GPfUiEJd09SeJPnUj7ZeXa0Wb2/JVIRDbSmyG/IYQqAvXWUcD4thuv2h9wbLgXyzvX8dtw==",
+      "version": "2.624.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.624.0.tgz",
+      "integrity": "sha512-6MhbdND7A5lEBiNSZ/HLwhKgrysmwTy6C47H7vfuVnY25hDkIND3C0PLqeRyskUqxv0RqsiAB4kqiMtpE08IGA==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -1892,9 +1892,9 @@
       }
     },
     "compare-versions": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.5.1.tgz",
-      "integrity": "sha512-9fGPIB7C6AyM18CJJBHt5EnCZDG3oiTJYy0NjfIAGjKpzv0tkxWko7TNQHF5ymqm7IH03tqmeuBxtvD+Izh6mg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
       "dev": true
     },
     "component-emitter": {
@@ -3569,9 +3569,9 @@
       }
     },
     "husky": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.2.1.tgz",
-      "integrity": "sha512-Qa0lRreeIf4Tl92sSs42ER6qc3hzoyQPPorzOrFWfPEVbdi6LuvJEqWKPk905fOWIR76iBpp7ECZNIwk+a8xuQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.2.3.tgz",
+      "integrity": "sha512-VxTsSTRwYveKXN4SaH1/FefRJYCtx+wx04sSVcOpD7N2zjoHxa+cEJ07Qg5NmV3HAK+IRKOyNVpi2YBIVccIfQ==",
       "dev": true,
       "requires": {
         "chalk": "^3.0.0",
@@ -6118,9 +6118,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "makeerror": {
@@ -7782,9 +7782,9 @@
       }
     },
     "ts-jest": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.2.0.tgz",
-      "integrity": "sha512-VaRdb0da46eorLfuHEFf0G3d+jeREcV+Wb/SvW71S4y9Oe8SHWU+m1WY/3RaMknrBsnvmVH0/rRjT8dkgeffNQ==",
+      "version": "25.2.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.2.1.tgz",
+      "integrity": "sha512-TnntkEEjuXq/Gxpw7xToarmHbAafgCaAzOpnajnFC6jI7oo1trMzAHA04eWpc3MhV6+yvhE8uUBAmN+teRJh0A==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
@@ -7796,22 +7796,17 @@
         "mkdirp": "0.x",
         "resolve": "1.x",
         "semver": "^5.5",
-        "yargs-parser": "10.x"
+        "yargs-parser": "^16.1.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
         "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -7867,9 +7862,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -19,19 +19,19 @@
   "dependencies": {
     "@actions/core": "^1.0.0",
     "@actions/exec": "^1.0.1",
-    "@actions/github": "^2.0.0",
-    "aws-sdk": "^2.588.0"
+    "@actions/github": "^2.1.1",
+    "aws-sdk": "^2.624.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.2",
-    "@typescript-eslint/eslint-plugin": "^2.10.0",
-    "@typescript-eslint/parser": "^2.10.0",
+    "@types/jest": "^25.1.3",
+    "@typescript-eslint/eslint-plugin": "^2.20.0",
+    "@typescript-eslint/parser": "^2.20.0",
     "@zeit/ncc": "^0.20.5",
     "eslint": "^6.7.2",
-    "husky": "^4.1.0",
+    "husky": "^4.2.3",
     "jest": "^24.9.0",
-    "ts-jest": "^25.2.0",
-    "typescript": "^3.7.5"
+    "ts-jest": "^25.2.1",
+    "typescript": "^3.8.2"
   },
   "husky": {
     "hooks": {

--- a/src/cw-build-status.ts
+++ b/src/cw-build-status.ts
@@ -8,16 +8,16 @@ const context = github.context
 const FAILED_BUILDS_METRIC_NAME = 'FailedBuilds'
 const NUM_BUILDS_METRIC_NAME = 'Builds'
 const SUCCESS_BUILDS_METRIC_NAME = 'SucceededBuilds'
-const PROJECT_DIMENSION = 'ProjectName'
-const IS_CRON_JOB_DIMENSION = 'IsCronJob'
+const SCHEDULE_EVENT_NAME = 'schedule'
 const EVENT_NAME_DIMENSION = 'EventName'
-const WORKFLOW_DIMENSION = 'Workflow'
-const REFERENCE_DIMENSION = 'Reference'
+const IS_CRON_JOB_DIMENSION = 'IsCronJob'
+const PROJECT_DIMENSION = 'ProjectName'
 const REPOSITORY_DIMENSION = 'Repository'
+const REFERENCE_DIMENSION = 'Reference'
+const WORKFLOW_DIMENSION = 'Workflow'
 const SUCCESS_METRIC_VALUE = 1.0
 const FAILED_METRIC_VALUE = 0.0
 const FAILED_BUILD_STATUS = 'failure'
-const SCHEDULE_EVENT_NAME = 'schedule'
 
 /**
  * Validate the `status` input to the action.
@@ -44,15 +44,15 @@ export function createMetricDatum(metricName: string, projectName: string, isCro
   const metric_datum = {
     'MetricName': metricName,
     'Value': value, 
-    'Dimensions': [ 
-      { 'Name': PROJECT_DIMENSION, 'Value': projectName },
-      { 'Name': IS_CRON_JOB_DIMENSION, 'Value': cronJobString },
+    'Dimensions': [
       { 'Name': EVENT_NAME_DIMENSION, 'Value': context.eventName },
-      { 'Name': WORKFLOW_DIMENSION, 'Value': context.workflow },
+      { 'Name': IS_CRON_JOB_DIMENSION, 'Value': cronJobString },
+      { 'Name': PROJECT_DIMENSION, 'Value': projectName },
       { 'Name': REFERENCE_DIMENSION, 'Value': context.ref },
       { 'Name': REPOSITORY_DIMENSION, 'Value': context.repo.repo },
-    ] 
-  } 
+      { 'Name': WORKFLOW_DIMENSION, 'Value': context.workflow },
+    ]
+  }
   return metric_datum
 }
 

--- a/src/cw-build-status.ts
+++ b/src/cw-build-status.ts
@@ -5,19 +5,19 @@ import CloudWatch from 'aws-sdk/clients/cloudwatch'
 const cloudwatch = new CloudWatch()
 const context = github.context
 
-const FAILED_BUILDS_METRIC_NAME = 'FailedBuilds'
-const NUM_BUILDS_METRIC_NAME = 'Builds'
-const SUCCESS_BUILDS_METRIC_NAME = 'SucceededBuilds'
-const SCHEDULE_EVENT_NAME = 'schedule'
 const EVENT_NAME_DIMENSION = 'EventName'
+const FAILED_BUILD_STATUS = 'failure'
+const FAILED_BUILDS_METRIC_NAME = 'FailedBuilds'
+const FAILED_METRIC_VALUE = 0.0
 const IS_CRON_JOB_DIMENSION = 'IsCronJob'
+const NUM_BUILDS_METRIC_NAME = 'Builds'
 const PROJECT_DIMENSION = 'ProjectName'
 const REPOSITORY_DIMENSION = 'Repository'
 const REFERENCE_DIMENSION = 'Reference'
-const WORKFLOW_DIMENSION = 'Workflow'
+const SCHEDULE_EVENT_NAME = 'schedule'
+const SUCCESS_BUILDS_METRIC_NAME = 'SucceededBuilds'
 const SUCCESS_METRIC_VALUE = 1.0
-const FAILED_METRIC_VALUE = 0.0
-const FAILED_BUILD_STATUS = 'failure'
+const WORKFLOW_DIMENSION = 'Workflow'
 
 /**
  * Validate the `status` input to the action.

--- a/src/cw-build-status.ts
+++ b/src/cw-build-status.ts
@@ -10,6 +10,10 @@ const NUM_BUILDS_METRIC_NAME = 'Builds'
 const SUCCESS_BUILDS_METRIC_NAME = 'SucceededBuilds'
 const PROJECT_DIMENSION = 'ProjectName'
 const IS_CRON_JOB_DIMENSION = 'IsCronJob'
+const EVENT_NAME_DIMENSION = 'EventName'
+const WORKFLOW_DIMENSION = 'Workflow'
+const REFERENCE_DIMENSION = 'Reference'
+const REPOSITORY_DIMENSION = 'Repository'
 const SUCCESS_METRIC_VALUE = 1.0
 const FAILED_METRIC_VALUE = 0.0
 const FAILED_BUILD_STATUS = 'failure'
@@ -42,7 +46,11 @@ export function createMetricDatum(metricName: string, projectName: string, isCro
     'Value': value, 
     'Dimensions': [ 
       { 'Name': PROJECT_DIMENSION, 'Value': projectName },
-      { 'Name': IS_CRON_JOB_DIMENSION, 'Value': cronJobString }
+      { 'Name': IS_CRON_JOB_DIMENSION, 'Value': cronJobString },
+      { 'Name': EVENT_NAME_DIMENSION, 'Value': context.eventName },
+      { 'Name': WORKFLOW_DIMENSION, 'Value': context.workflow },
+      { 'Name': REFERENCE_DIMENSION, 'Value': context.ref },
+      { 'Name': REPOSITORY_DIMENSION, 'Value': context.repo.repo },
     ] 
   } 
   return metric_datum


### PR DESCRIPTION
Add GitHub context to the metric dimensions.

For reference, the GitHub context can be found [here](https://github.com/actions/toolkit/blob/ac007c06984bc483fae2ba649788dfc858bc6a8b/packages/github/src/context.ts#L23).
It is mocked based on the GitHub Action toolkit [docs](https://github.com/actions/toolkit/blob/5feb835dff800f53c9f6d8989f0b503262aade87/docs/github-package.md#mocking-the-github-context).

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>