### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,15 @@
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date as soon as
+  # new versions are published to the npm registry
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    # Apply default reviewer and label to created
+    # pull requests
+    default_reviewers:
+      - "ros-tooling/approvers"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:minor"


### PR DESCRIPTION
See official [config docs](https://dependabot.com/docs/config-file).

* Automerge all minor updates
* Automatically assign `ros-tooling/approvers` as reviewers 

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>